### PR TITLE
Use marketplace branch for awesome-copilot marketplace

### DIFF
--- a/src/Services/Marketplace/MarketplaceStorageService.cs
+++ b/src/Services/Marketplace/MarketplaceStorageService.cs
@@ -40,7 +40,7 @@ namespace GitHubNode.Services.Marketplace
         /// </summary>
         public static IReadOnlyList<MarketplaceEntry> BuiltInMarketplaces { get; } = new List<MarketplaceEntry>
         {
-            new MarketplaceEntry { Owner = "github", Repo = "awesome-copilot", Branch = "main" },
+            new MarketplaceEntry { Owner = "github", Repo = "awesome-copilot", Branch = "marketplace" },
             new MarketplaceEntry { Owner = "github", Repo = "copilot-plugins", Branch = "main" },
             new MarketplaceEntry { Owner = "dotnet", Repo = "skills", Branch = "main" },
             new MarketplaceEntry { Owner = "anthropics", Repo = "skills", Branch = "main" }

--- a/test/GitHubNode.Test/MarketplaceStorageServiceTests.cs
+++ b/test/GitHubNode.Test/MarketplaceStorageServiceTests.cs
@@ -16,6 +16,15 @@ public class MarketplaceStorageServiceTests
     }
 
     [TestMethod]
+    public void BuiltInMarketplaces_AwesomeCopilot_UsesMarketplaceBranch()
+    {
+        var marketplace = MarketplaceStorageService.BuiltInMarketplaces
+            .Single(m => m.Owner == "github" && m.Repo == "awesome-copilot");
+
+        Assert.AreEqual("marketplace", marketplace.Branch);
+    }
+
+    [TestMethod]
     public void GetMarketplaceId_ReturnsOwnerSlashRepo()
     {
         string id = MarketplaceStorageService.GetMarketplaceId("myowner", "myrepo");


### PR DESCRIPTION
## Why
The built-in github/awesome-copilot marketplace should load from its marketplace branch rather than relying on the repository default branch. See https://github.com/github/awesome-copilot/issues/1368 for full context.

## What changed
- Updated the built-in marketplace entry to use Branch = "marketplace" for github/awesome-copilot.
- Added a regression test to ensure the built-in entry continues to use the marketplace branch.

## Notes
This only affects the built-in branch selection for that marketplace entry and does not change behavior for other marketplaces.