### PR TITLE
Support external marketplace plugin refs and commit pinning

### DIFF
--- a/src/Services/Marketplace/MarketplaceGitService.cs
+++ b/src/Services/Marketplace/MarketplaceGitService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +15,7 @@ namespace GitHubNode.Services.Marketplace
     {
         private const int _gitTimeoutSeconds = 120;
         private static readonly SemaphoreSlim _gitLock = new SemaphoreSlim(1, 1);
+        private static readonly Regex _commitShaRegex = new Regex("^[0-9a-fA-F]{40}$", RegexOptions.Compiled);
 
         /// <summary>
         /// Result of a git operation.
@@ -69,7 +71,10 @@ namespace GitHubNode.Services.Marketplace
         /// <param name="parentMarketplaceRepo">Repository name of the parent marketplace.</param>
         /// <param name="linkedOwner">Owner of the linked repository.</param>
         /// <param name="linkedRepo">Repository name of the linked repository.</param>
-        /// <param name="branch">Branch to clone. If null or empty, the default branch is detected automatically.</param>
+        /// <param name="ref">Branch or tag to checkout. If null or empty and sha is not provided, the default branch is detected automatically.</param>
+        /// <param name="sha">Commit sha to checkout. Takes precedence over ref when both are provided.</param>
+        /// <param name="linkedRepositoryUrl">Optional explicit linked repository URL.</param>
+        /// <param name="parentRepositoryUrl">Optional explicit parent repository URL.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Result of the git operation and the local path to the cloned repo.</returns>
         public static async Task<(GitResult Result, string LocalPath)> CloneLinkedRepositoryAsync(
@@ -77,7 +82,8 @@ namespace GitHubNode.Services.Marketplace
             string parentMarketplaceRepo,
             string linkedOwner,
             string linkedRepo,
-            string branch = null,
+            string @ref = null,
+            string sha = null,
             string linkedRepositoryUrl = null,
             string parentRepositoryUrl = null,
             CancellationToken cancellationToken = default)
@@ -86,10 +92,17 @@ namespace GitHubNode.Services.Marketplace
                 parentMarketplaceOwner, parentMarketplaceRepo, linkedOwner, linkedRepo, parentRepositoryUrl, linkedRepositoryUrl);
             var cloneUrl = MarketplaceRepositoryUrl.GetCloneUrl(linkedOwner, linkedRepo, linkedRepositoryUrl);
 
-            // If branch is not specified, detect it from the remote
-            if (string.IsNullOrEmpty(branch))
+            // Backward compatible behavior: marketplace sources may provide a commit hash via `ref`.
+            if (string.IsNullOrEmpty(sha) && LooksLikeCommitSha(@ref))
             {
-                branch = await GetDefaultBranchAsync(linkedOwner, linkedRepo, linkedRepositoryUrl, cancellationToken);
+                sha = @ref;
+                @ref = null;
+            }
+
+            // If neither sha nor ref is specified, detect the default branch from the remote.
+            if (string.IsNullOrEmpty(sha) && string.IsNullOrEmpty(@ref))
+            {
+                @ref = await GetDefaultBranchAsync(linkedOwner, linkedRepo, linkedRepositoryUrl, cancellationToken);
             }
 
             await _gitLock.WaitAsync(cancellationToken);
@@ -97,14 +110,14 @@ namespace GitHubNode.Services.Marketplace
             {
                 if (Directory.Exists(Path.Combine(localPath, ".git")))
                 {
-                    // Linked repo already cloned, do a pull
-                    var result = await PullAsync(localPath, branch, cancellationToken);
+                    // Linked repo already cloned - sync to the requested ref/sha.
+                    var result = await SyncLinkedRepositoryAsync(localPath, @ref, sha, cancellationToken);
                     return (result, localPath);
                 }
                 else
                 {
                     // Clone the linked repository
-                    var result = await CloneAsync(cloneUrl, localPath, branch, cancellationToken);
+                    var result = await CloneLinkedRepositoryAsync(cloneUrl, localPath, @ref, sha, cancellationToken);
                     return (result, localPath);
                 }
             }
@@ -280,6 +293,105 @@ namespace GitHubNode.Services.Marketplace
         }
 
         /// <summary>
+        /// Clones a linked repository, respecting either a ref (branch or tag) or a commit sha.
+        /// </summary>
+        private static async Task<GitResult> CloneLinkedRepositoryAsync(
+            string cloneUrl,
+            string localPath,
+            string @ref,
+            string sha,
+            CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrWhiteSpace(sha))
+            {
+                // Clone without checkout, then fetch and checkout the requested commit.
+                var cloneResult = await CloneWithoutCheckoutAsync(cloneUrl, localPath, cancellationToken);
+                if (!cloneResult.Success)
+                {
+                    return cloneResult;
+                }
+
+                return await SyncLinkedRepositoryAsync(localPath, @ref: null, sha, cancellationToken);
+            }
+
+            return await CloneAsync(cloneUrl, localPath, @ref, cancellationToken);
+        }
+
+        /// <summary>
+        /// Syncs an existing linked repository to a specific ref (branch/tag) or commit sha.
+        /// </summary>
+        private static async Task<GitResult> SyncLinkedRepositoryAsync(
+            string localPath,
+            string @ref,
+            string sha,
+            CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrWhiteSpace(sha))
+            {
+                var fetchShaResult = await RunGitAsync($"fetch --depth 1 origin \"{sha}\"", localPath, cancellationToken);
+                if (!fetchShaResult.Success)
+                {
+                    return fetchShaResult;
+                }
+
+                return await RunGitAsync($"checkout --detach \"{sha}\"", localPath, cancellationToken);
+            }
+
+            if (string.IsNullOrWhiteSpace(@ref))
+            {
+                return new GitResult
+                {
+                    Success = false,
+                    Error = "A branch/tag ref or commit sha is required to sync a linked repository.",
+                    ExitCode = -1
+                };
+            }
+
+            // Fetch the requested ref and detach to the fetched commit.
+            var fetchRefResult = await RunGitAsync($"fetch --depth 1 origin \"{@ref}\"", localPath, cancellationToken);
+            if (!fetchRefResult.Success)
+            {
+                return fetchRefResult;
+            }
+
+            return await RunGitAsync("checkout --detach FETCH_HEAD", localPath, cancellationToken);
+        }
+
+        /// <summary>
+        /// Clones a repository without checking out a working tree.
+        /// </summary>
+        private static async Task<GitResult> CloneWithoutCheckoutAsync(
+            string cloneUrl,
+            string localPath,
+            CancellationToken cancellationToken)
+        {
+            // Ensure parent directory exists and target doesn't
+            var parentDir = Path.GetDirectoryName(localPath);
+            if (!string.IsNullOrEmpty(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+
+            if (Directory.Exists(localPath))
+            {
+                // Clean up partial clone
+                try
+                {
+                    MarketplaceStorageService.DeleteMarketplaceClone(
+                        Path.GetFileName(Path.GetDirectoryName(localPath)),
+                        Path.GetFileName(localPath));
+                }
+                catch
+                {
+                    // Best effort
+                }
+            }
+
+            var args = $"clone --no-checkout --depth 1 \"{cloneUrl}\" \"{localPath}\"";
+            return await RunGitAsync(args, workingDirectory: null, cancellationToken);
+        }
+
+        /// <summary>
         /// Runs a git command and returns the result.
         /// </summary>
         private static async Task<GitResult> RunGitAsync(
@@ -386,6 +498,11 @@ namespace GitHubNode.Services.Marketplace
             {
                 // Best effort
             }
+        }
+
+        private static bool LooksLikeCommitSha(string value)
+        {
+            return !string.IsNullOrWhiteSpace(value) && _commitShaRegex.IsMatch(value);
         }
     }
 }

--- a/src/Services/Marketplace/MarketplaceParserService.cs
+++ b/src/Services/Marketplace/MarketplaceParserService.cs
@@ -70,6 +70,17 @@ namespace GitHubNode.Services.Marketplace
             /// The path within the external repository.
             /// </summary>
             public string path { get; set; }
+
+            /// <summary>
+            /// Optional branch or tag to checkout for the external repository.
+            /// </summary>
+            public string @ref { get; set; }
+
+            /// <summary>
+            /// Optional commit sha to checkout for the external repository.
+            /// When specified, this takes precedence over the ref value.
+            /// </summary>
+            public string sha { get; set; }
         }
 
         private sealed class RawPlugin
@@ -291,7 +302,15 @@ namespace GitHubNode.Services.Marketplace
                         try
                         {
                             var (result, clonedPath) = await MarketplaceGitService.CloneLinkedRepositoryAsync(
-                                parentOwner, parentRepo, linkedOwner, linkedRepo, linkedRepositoryUrl: linkedRepositoryUrl, parentRepositoryUrl: parentRepositoryUrl, cancellationToken: cancellationToken);
+                                parentOwner,
+                                parentRepo,
+                                linkedOwner,
+                                linkedRepo,
+                                @ref: linkedSource.@ref,
+                                sha: linkedSource.sha,
+                                linkedRepositoryUrl: linkedRepositoryUrl,
+                                parentRepositoryUrl: parentRepositoryUrl,
+                                cancellationToken: cancellationToken);
 
                             if (!result.Success)
                             {

--- a/test/GitHubNode.Test/MarketplaceGitServiceTests.cs
+++ b/test/GitHubNode.Test/MarketplaceGitServiceTests.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics;
+using System.Text;
+using GitHubNode.Services.Marketplace;
+
+namespace GitHubNode.Test;
+
+[TestClass]
+public class MarketplaceGitServiceTests
+{
+    [TestMethod]
+    public async Task CloneLinkedRepositoryAsync_RespectsRefForBranchAndTag()
+    {
+        var originRepoPath = CreateTempDirectory();
+        var linkedBranchPath = string.Empty;
+        var linkedTagPath = string.Empty;
+
+        try
+        {
+            var (initialSha, featureSha) = CreateRepositoryWithFeatureBranchAndTag(originRepoPath);
+            var parentOwner = "parent-" + Guid.NewGuid().ToString("N");
+            var parentRepo = "marketplace";
+
+            var (branchResult, branchLocalPath) = await MarketplaceGitService.CloneLinkedRepositoryAsync(
+                parentOwner,
+                parentRepo,
+                linkedOwner: "linked",
+                linkedRepo: "branch-repo",
+                @ref: "feature",
+                linkedRepositoryUrl: originRepoPath);
+
+            linkedBranchPath = branchLocalPath;
+            Assert.IsTrue(branchResult.Success, branchResult.Error);
+            var checkedOutFeatureSha = RunGit(branchLocalPath, "rev-parse HEAD").Trim();
+            Assert.AreEqual(featureSha, checkedOutFeatureSha, "Expected linked clone to checkout the requested branch ref.");
+
+            var (tagResult, tagLocalPath) = await MarketplaceGitService.CloneLinkedRepositoryAsync(
+                parentOwner,
+                parentRepo,
+                linkedOwner: "linked",
+                linkedRepo: "tag-repo",
+                @ref: "v1",
+                linkedRepositoryUrl: originRepoPath);
+
+            linkedTagPath = tagLocalPath;
+            Assert.IsTrue(tagResult.Success, tagResult.Error);
+            var checkedOutTagSha = RunGit(tagLocalPath, "rev-parse HEAD").Trim();
+            Assert.AreEqual(initialSha, checkedOutTagSha, "Expected linked clone to checkout the requested tag ref.");
+        }
+        finally
+        {
+            DeleteDirectory(linkedBranchPath);
+            DeleteDirectory(linkedTagPath);
+            DeleteDirectory(originRepoPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task CloneLinkedRepositoryAsync_PrioritizesShaOverRef()
+    {
+        var originRepoPath = CreateTempDirectory();
+        var linkedPath = string.Empty;
+
+        try
+        {
+            var (initialSha, _) = CreateRepositoryWithFeatureBranchAndTag(originRepoPath);
+
+            var (result, localPath) = await MarketplaceGitService.CloneLinkedRepositoryAsync(
+                parentMarketplaceOwner: "parent-" + Guid.NewGuid().ToString("N"),
+                parentMarketplaceRepo: "marketplace",
+                linkedOwner: "linked",
+                linkedRepo: "sha-repo",
+                @ref: "feature",
+                sha: initialSha,
+                linkedRepositoryUrl: originRepoPath);
+
+            linkedPath = localPath;
+            Assert.IsTrue(result.Success, result.Error);
+            var checkedOutSha = RunGit(localPath, "rev-parse HEAD").Trim();
+            Assert.AreEqual(initialSha, checkedOutSha, "Expected linked clone to checkout the requested sha when both sha and ref are provided.");
+        }
+        finally
+        {
+            DeleteDirectory(linkedPath);
+            DeleteDirectory(originRepoPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task CloneLinkedRepositoryAsync_TreatsCommitHashRefAsSha()
+    {
+        var originRepoPath = CreateTempDirectory();
+        var linkedPath = string.Empty;
+
+        try
+        {
+            var (initialSha, _) = CreateRepositoryWithFeatureBranchAndTag(originRepoPath);
+
+            var (result, localPath) = await MarketplaceGitService.CloneLinkedRepositoryAsync(
+                parentMarketplaceOwner: "parent-" + Guid.NewGuid().ToString("N"),
+                parentMarketplaceRepo: "marketplace",
+                linkedOwner: "linked",
+                linkedRepo: "ref-as-sha-repo",
+                @ref: initialSha,
+                linkedRepositoryUrl: originRepoPath);
+
+            linkedPath = localPath;
+            Assert.IsTrue(result.Success, result.Error);
+            var checkedOutSha = RunGit(localPath, "rev-parse HEAD").Trim();
+            Assert.AreEqual(initialSha, checkedOutSha, "Expected sha-looking ref values to be treated as commit checkouts.");
+        }
+        finally
+        {
+            DeleteDirectory(linkedPath);
+            DeleteDirectory(originRepoPath);
+        }
+    }
+
+    private static (string InitialSha, string FeatureSha) CreateRepositoryWithFeatureBranchAndTag(string repoPath)
+    {
+        Directory.CreateDirectory(repoPath);
+        RunGit(repoPath, "init");
+        RunGit(repoPath, "config user.email test@example.com");
+        RunGit(repoPath, "config user.name Test User");
+        RunGit(repoPath, "branch -M main");
+
+        var trackedFile = Path.Combine(repoPath, "README.md");
+        File.WriteAllText(trackedFile, "initial");
+        RunGit(repoPath, "add README.md");
+        RunGit(repoPath, "commit -m \"initial\"");
+
+        var initialSha = RunGit(repoPath, "rev-parse HEAD").Trim();
+        RunGit(repoPath, $"tag v1 {initialSha}");
+
+        RunGit(repoPath, "checkout -b feature");
+        File.WriteAllText(trackedFile, "feature");
+        RunGit(repoPath, "add README.md");
+        RunGit(repoPath, "commit -m \"feature\"");
+        var featureSha = RunGit(repoPath, "rev-parse HEAD").Trim();
+
+        RunGit(repoPath, "checkout main");
+
+        return (initialSha, featureSha);
+    }
+
+    private static string RunGit(string workingDirectory, string arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
+        };
+
+        using var process = Process.Start(startInfo);
+        Assert.IsNotNull(process, $"Failed to start git process: git {arguments}");
+
+        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            Assert.Fail($"Git command failed ({process.ExitCode}): git {arguments}{Environment.NewLine}STDOUT:{Environment.NewLine}{stdOut}{Environment.NewLine}STDERR:{Environment.NewLine}{stdErr}");
+        }
+
+        return stdOut;
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "GitHubNode.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+        }
+
+        Directory.Delete(path, recursive: true);
+    }
+}


### PR DESCRIPTION
## Why
External plugins in marketplace manifests can point to another repository and pin content to a specific version. We needed linked marketplace cloning to honor those pins so plugin resolution is deterministic.

## What changed
- Added ef and sha support to external plugin source parsing in marketplace.json.
- Updated linked repository clone/update logic to:
  - checkout branch/tag refs when ef is provided,
  - checkout a specific commit when sha is provided,
  - treat 40-character hex ef values as commit SHAs for compatibility with existing manifests that pin via ef.
- Added focused tests in MarketplaceGitServiceTests covering branch refs, tag refs, explicit SHA, and ref-as-SHA behavior.

## Notes for reviewers
The linked-repo sync path now uses detached checkouts for pinned refs/SHAs to avoid branch-state assumptions and keep linked plugin content stable across updates.